### PR TITLE
解决项目引入项目后在未做lock配置时启动报错的问题

### DIFF
--- a/src/main/java/org/springframework/boot/autoconfigure/klock/KlockAutoConfiguration.java
+++ b/src/main/java/org/springframework/boot/autoconfigure/klock/KlockAutoConfiguration.java
@@ -8,6 +8,7 @@ import org.redisson.config.Config;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration;
 import org.springframework.boot.autoconfigure.klock.config.KlockConfig;
 import org.springframework.boot.autoconfigure.klock.core.BusinessKeyProvider;
@@ -25,6 +26,7 @@ import org.springframework.util.ClassUtils;
  * Content :klock自动装配
  */
 @Configuration
+@ConditionalOnProperty(KlockConfig.PREFIX)
 @AutoConfigureAfter(RedisAutoConfiguration.class)
 @EnableConfigurationProperties(KlockConfig.class)
 @Import({KlockAspectHandler.class})


### PR DESCRIPTION
增加了可选配置  解决启动报错