### PR TITLE
支持联锁

### DIFF
--- a/src/main/java/org/springframework/boot/autoconfigure/klock/core/BusinessKeyProvider.java
+++ b/src/main/java/org/springframework/boot/autoconfigure/klock/core/BusinessKeyProvider.java
@@ -30,17 +30,18 @@ public class BusinessKeyProvider {
 
     private ExpressionParser parser = new SpelExpressionParser();
 
-    public String getKeyName(JoinPoint joinPoint, Klock klock) {
+    public String getKeyName(JoinPoint joinPoint, Klock klock, String parameterKey) {
         List<String> keyList = new ArrayList<>();
         Method method = getMethod(joinPoint);
         List<String> definitionKeys = getSpelDefinitionKey(klock.keys(), method, joinPoint.getArgs());
         keyList.addAll(definitionKeys);
-        List<String> parameterKeys = getParameterKey(method.getParameters(), joinPoint.getArgs());
-        keyList.addAll(parameterKeys);
-        return StringUtils.collectionToDelimitedString(keyList,"","-","");
+        if(!StringUtils.isEmpty(parameterKey)) {
+            keyList.add(parameterKey);
+        }
+        return StringUtils.collectionToDelimitedString(keyList, "", "-", "");
     }
 
-    private Method getMethod(JoinPoint joinPoint) {
+    public Method getMethod(JoinPoint joinPoint) {
         MethodSignature signature = (MethodSignature) joinPoint.getSignature();
         Method method = signature.getMethod();
         if (method.getDeclaringClass().isInterface()) {
@@ -66,7 +67,7 @@ public class BusinessKeyProvider {
         return definitionKeyList;
     }
 
-    private List<String> getParameterKey(Parameter[] parameters, Object[] parameterValues) {
+    public List<String> getParameterKey(Parameter[] parameters, Object[] parameterValues) {
         List<String> parameterKey = new ArrayList<>();
         for (int i = 0; i < parameters.length; i++) {
             if (parameters[i].getAnnotation(KlockKey.class) != null) {

--- a/src/main/java/org/springframework/boot/autoconfigure/klock/core/KlockAspectHandler.java
+++ b/src/main/java/org/springframework/boot/autoconfigure/klock/core/KlockAspectHandler.java
@@ -21,6 +21,8 @@ import org.springframework.util.StringUtils;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
@@ -42,53 +44,68 @@ public class KlockAspectHandler {
     @Autowired
     private LockInfoProvider lockInfoProvider;
 
-    private final Map<String,LockRes> currentThreadLock = new ConcurrentHashMap<>();
+    private final Map<String, LockRes> currentThreadLock = new ConcurrentHashMap<>();
 
 
     @Around(value = "@annotation(klock)")
     public Object around(ProceedingJoinPoint joinPoint, Klock klock) throws Throwable {
-        LockInfo lockInfo = lockInfoProvider.get(joinPoint,klock);
-        String currentLock = this.getCurrentLockId(joinPoint,klock);
-        currentThreadLock.put(currentLock,new LockRes(lockInfo, false));
-        Lock lock = lockFactory.getLock(lockInfo);
+        List<LockInfo> lockInfos = lockInfoProvider.get(joinPoint, klock);
+        List<String> currentLockIds = new ArrayList<>();
+        lockInfos.forEach(lockInfo -> {
+            String currentLockId = this.getCurrentLockId(lockInfo);
+            currentThreadLock.put(currentLockId, new LockRes(lockInfo, false));
+            currentLockIds.add(currentLockId);
+        });
+        Lock lock = lockFactory.getLock((LockInfo[]) lockInfos.toArray(new LockInfo[]{}));
         boolean lockRes = lock.acquire();
 
         //如果获取锁失败了，则进入失败的处理逻辑
-        if(!lockRes) {
-            if(logger.isWarnEnabled()) {
-                logger.warn("Timeout while acquiring Lock({})", lockInfo.getName());
+        if (!lockRes) {
+            if (logger.isWarnEnabled()) {
+                logger.warn("Timeout while acquiring Lock({})", lock.name);
             }
             //如果自定义了获取锁失败的处理策略，则执行自定义的降级处理策略
-            if(!StringUtils.isEmpty(klock.customLockTimeoutStrategy())) {
+            if (!StringUtils.isEmpty(klock.customLockTimeoutStrategy())) {
 
                 return handleCustomLockTimeout(klock.customLockTimeoutStrategy(), joinPoint);
 
             } else {
                 //否则执行预定义的执行策略
                 //注意：如果没有指定预定义的策略，默认的策略为静默啥不做处理
-                klock.lockTimeoutStrategy().handle(lockInfo, lock, joinPoint);
+                lockInfos.forEach(lockInfo -> {
+                    klock.lockTimeoutStrategy().handle(lockInfo, lock, joinPoint);
+                });
             }
         }
-
-        currentThreadLock.get(currentLock).setLock(lock);
-        currentThreadLock.get(currentLock).setRes(true);
-
+        currentLockIds.forEach(currentLockId -> {
+            currentThreadLock.get(currentLockId).setLock(lock);
+            currentThreadLock.get(currentLockId).setRes(true);
+        });
         return joinPoint.proceed();
     }
 
     @AfterReturning(value = "@annotation(klock)")
-    public void afterReturning(JoinPoint joinPoint, Klock klock) throws Throwable {
-        String currentLock = this.getCurrentLockId(joinPoint,klock);
-        releaseLock(klock, joinPoint,currentLock);
-        cleanUpThreadLocal(currentLock);
+    public void afterReturning(JoinPoint joinPoint, Klock klock) {
+        releaseLock(joinPoint, klock);
     }
 
     @AfterThrowing(value = "@annotation(klock)", throwing = "ex")
-    public void afterThrowing (JoinPoint joinPoint, Klock klock, Throwable ex) throws Throwable {
-        String currentLock = this.getCurrentLockId(joinPoint,klock);
-        releaseLock(klock, joinPoint,currentLock);
-        cleanUpThreadLocal(currentLock);
+    public void afterThrowing(JoinPoint joinPoint, Klock klock, Throwable ex) throws Throwable {
+        releaseLock(joinPoint, klock);
         throw ex;
+    }
+
+    private void releaseLock(JoinPoint joinPoint, Klock klock) {
+        List<LockInfo> lockInfos = lockInfoProvider.get(joinPoint, klock);
+        lockInfos.forEach(lockInfo -> {
+            try {
+                String currentLock = this.getCurrentLockId(lockInfo);
+                releaseLock(klock, joinPoint, currentLock);
+                cleanUpThreadLocal(currentLock);
+            } catch (Throwable throwable) {
+                throw new RuntimeException("release lock fail ", throwable);
+            }
+        });
     }
 
     /**
@@ -97,14 +114,14 @@ public class KlockAspectHandler {
     private Object handleCustomLockTimeout(String lockTimeoutHandler, JoinPoint joinPoint) throws Throwable {
 
         // prepare invocation context
-        Method currentMethod = ((MethodSignature)joinPoint.getSignature()).getMethod();
+        Method currentMethod = ((MethodSignature) joinPoint.getSignature()).getMethod();
         Object target = joinPoint.getTarget();
         Method handleMethod = null;
         try {
             handleMethod = joinPoint.getTarget().getClass().getDeclaredMethod(lockTimeoutHandler, currentMethod.getParameterTypes());
             handleMethod.setAccessible(true);
         } catch (NoSuchMethodException e) {
-            throw new IllegalArgumentException("Illegal annotation param customLockTimeoutStrategy",e);
+            throw new IllegalArgumentException("Illegal annotation param customLockTimeoutStrategy", e);
         }
         Object[] args = joinPoint.getArgs();
 
@@ -113,7 +130,7 @@ public class KlockAspectHandler {
         try {
             res = handleMethod.invoke(target, args);
         } catch (IllegalAccessException e) {
-            throw new KlockInvocationException("Fail to invoke custom lock timeout handler: " + lockTimeoutHandler ,e);
+            throw new KlockInvocationException("Fail to invoke custom lock timeout handler: " + lockTimeoutHandler, e);
         } catch (InvocationTargetException e) {
             throw e.getTargetException();
         }
@@ -122,11 +139,11 @@ public class KlockAspectHandler {
     }
 
     /**
-     *  释放锁
+     * 释放锁
      */
-    private void releaseLock(Klock klock, JoinPoint joinPoint,String currentLock) throws Throwable {
+    private void releaseLock(Klock klock, JoinPoint joinPoint, String currentLock) throws Throwable {
         LockRes lockRes = currentThreadLock.get(currentLock);
-        if(Objects.isNull(lockRes)){
+        if (Objects.isNull(lockRes)) {
             throw new NullPointerException("Please check whether the input parameter used as the lock key value has been modified in the method, which will cause the acquire and release locks to have different key values and throw null pointers.currentLockKey:" + currentLock);
         }
         if (lockRes.getRes()) {
@@ -146,26 +163,25 @@ public class KlockAspectHandler {
 
     /**
      * 获取当前锁在map中的key
-     * @param joinPoint
-     * @param klock
+     *
+     * @param lockInfo
      * @return
      */
-    private String getCurrentLockId(JoinPoint joinPoint , Klock klock){
-        LockInfo lockInfo = lockInfoProvider.get(joinPoint,klock);
-        String currentLock= Thread.currentThread().getId() + lockInfo.getName();
+    private String getCurrentLockId(LockInfo lockInfo) {
+        String currentLock = Thread.currentThread().getId() + lockInfo.getName();
         return currentLock;
     }
 
     /**
-     *  处理释放锁时已超时
+     * 处理释放锁时已超时
      */
     private void handleReleaseTimeout(Klock klock, LockInfo lockInfo, JoinPoint joinPoint) throws Throwable {
 
-        if(logger.isWarnEnabled()) {
+        if (logger.isWarnEnabled()) {
             logger.warn("Timeout while release Lock({})", lockInfo.getName());
         }
 
-        if(!StringUtils.isEmpty(klock.customReleaseTimeoutStrategy())) {
+        if (!StringUtils.isEmpty(klock.customReleaseTimeoutStrategy())) {
 
             handleCustomReleaseTimeout(klock.customReleaseTimeoutStrategy(), joinPoint);
 
@@ -180,14 +196,14 @@ public class KlockAspectHandler {
      */
     private void handleCustomReleaseTimeout(String releaseTimeoutHandler, JoinPoint joinPoint) throws Throwable {
 
-        Method currentMethod = ((MethodSignature)joinPoint.getSignature()).getMethod();
+        Method currentMethod = ((MethodSignature) joinPoint.getSignature()).getMethod();
         Object target = joinPoint.getTarget();
         Method handleMethod = null;
         try {
             handleMethod = joinPoint.getTarget().getClass().getDeclaredMethod(releaseTimeoutHandler, currentMethod.getParameterTypes());
             handleMethod.setAccessible(true);
         } catch (NoSuchMethodException e) {
-            throw new IllegalArgumentException("Illegal annotation param customReleaseTimeoutStrategy",e);
+            throw new IllegalArgumentException("Illegal annotation param customReleaseTimeoutStrategy", e);
         }
         Object[] args = joinPoint.getArgs();
 

--- a/src/main/java/org/springframework/boot/autoconfigure/klock/core/LockInfoProvider.java
+++ b/src/main/java/org/springframework/boot/autoconfigure/klock/core/LockInfoProvider.java
@@ -30,23 +30,24 @@ public class LockInfoProvider {
 
     LockInfo get(JoinPoint joinPoint, Klock klock) {
         MethodSignature signature = (MethodSignature) joinPoint.getSignature();
-        LockType type= klock.lockType();
-        String businessKeyName=businessKeyProvider.getKeyName(joinPoint,klock);
+        LockType type = klock.lockType();
+        String businessKeyName = businessKeyProvider.getKeyName(joinPoint, klock);
         //锁的名字，锁的粒度就是这里控制的
         String lockName = LOCK_NAME_PREFIX + LOCK_NAME_SEPARATOR + getName(klock.name(), signature) + businessKeyName;
         long waitTime = getWaitTime(klock);
         long leaseTime = getLeaseTime(klock);
         //如果占用锁的时间设计不合理，则打印相应的警告提示
-        if(leaseTime == -1 && logger.isWarnEnabled()) {
+        if (leaseTime == -1 && logger.isWarnEnabled()) {
             logger.warn("Trying to acquire Lock({}) with no expiration, " +
-                        "Klock will keep prolong the lock expiration while the lock is still holding by current thread. " +
-                        "This may cause dead lock in some circumstances.", lockName);
+                    "Klock will keep prolong the lock expiration while the lock is still holding by current thread. " +
+                    "This may cause dead lock in some circumstances.", lockName);
         }
-        return new LockInfo(type,lockName,waitTime,leaseTime);
+        return new LockInfo(type, lockName, waitTime, leaseTime);
     }
 
     /**
      * 获取锁的name，如果没有指定，则按全类名拼接方法名处理
+     *
      * @param annotationName
      * @param signature
      * @return

--- a/src/main/java/org/springframework/boot/autoconfigure/klock/core/LockInfoProvider.java
+++ b/src/main/java/org/springframework/boot/autoconfigure/klock/core/LockInfoProvider.java
@@ -11,6 +11,10 @@ import org.springframework.boot.autoconfigure.klock.model.LockInfo;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.springframework.boot.autoconfigure.klock.model.LockType;
 
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * Created by kl on 2017/12/29.
  */
@@ -28,21 +32,39 @@ public class LockInfoProvider {
 
     private static final Logger logger = LoggerFactory.getLogger(LockInfoProvider.class);
 
-    LockInfo get(JoinPoint joinPoint, Klock klock) {
+    List<LockInfo> get(JoinPoint joinPoint, Klock klock) {
+        List<LockInfo> lockInfos = new ArrayList<>();
         MethodSignature signature = (MethodSignature) joinPoint.getSignature();
         LockType type = klock.lockType();
-        String businessKeyName = businessKeyProvider.getKeyName(joinPoint, klock);
-        //锁的名字，锁的粒度就是这里控制的
-        String lockName = LOCK_NAME_PREFIX + LOCK_NAME_SEPARATOR + getName(klock.name(), signature) + businessKeyName;
+        Method method = businessKeyProvider.getMethod(joinPoint);
+        List<String> parameterKeys = businessKeyProvider.getParameterKey(method.getParameters(), joinPoint.getArgs());
+
         long waitTime = getWaitTime(klock);
         long leaseTime = getLeaseTime(klock);
-        //如果占用锁的时间设计不合理，则打印相应的警告提示
+
+        if (parameterKeys.size() > 0) {
+            parameterKeys.forEach(parameterKey -> {
+                String businessKeyName = businessKeyProvider.getKeyName(joinPoint, klock, parameterKey);
+                //锁的名字，锁的粒度就是这里控制的
+                addLockInfo(klock, lockInfos, signature, type, waitTime, leaseTime, businessKeyName);
+            });
+        } else {
+            String businessKeyName = businessKeyProvider.getKeyName(joinPoint, klock, null);
+            //锁的名字，锁的粒度就是这里控制的
+            addLockInfo(klock, lockInfos, signature, type, waitTime, leaseTime, businessKeyName);
+        }
+
+        return lockInfos;
+    }
+
+    private void addLockInfo(Klock klock, List<LockInfo> lockInfos, MethodSignature signature, LockType type, long waitTime, long leaseTime, String businessKeyName) {
+        String lockName = LOCK_NAME_PREFIX + LOCK_NAME_SEPARATOR + getName(klock.name(), signature) + businessKeyName;
         if (leaseTime == -1 && logger.isWarnEnabled()) {
             logger.warn("Trying to acquire Lock({}) with no expiration, " +
                     "Klock will keep prolong the lock expiration while the lock is still holding by current thread. " +
                     "This may cause dead lock in some circumstances.", lockName);
         }
-        return new LockInfo(type, lockName, waitTime, leaseTime);
+        lockInfos.add(new LockInfo(type, lockName, waitTime, leaseTime));
     }
 
     /**

--- a/src/main/java/org/springframework/boot/autoconfigure/klock/lock/FairLock.java
+++ b/src/main/java/org/springframework/boot/autoconfigure/klock/lock/FairLock.java
@@ -12,13 +12,15 @@ import java.util.concurrent.TimeUnit;
  */
 public class FairLock implements Lock {
 
-    private  RLock rLock;
-    
+    private String name;
+
+    private RLock rLock;
+
     private final LockInfo lockInfo;
 
     private RedissonClient redissonClient;
 
-    public FairLock(RedissonClient redissonClient,LockInfo info) {
+    public FairLock(RedissonClient redissonClient, LockInfo info) {
         this.redissonClient = redissonClient;
         this.lockInfo = info;
     }
@@ -26,7 +28,8 @@ public class FairLock implements Lock {
     @Override
     public boolean acquire() {
         try {
-            rLock=redissonClient.getFairLock(lockInfo.getName());
+            name = lockInfo.getName();
+            rLock = redissonClient.getFairLock(name);
             return rLock.tryLock(lockInfo.getWaitTime(), lockInfo.getLeaseTime(), TimeUnit.SECONDS);
         } catch (InterruptedException e) {
             return false;
@@ -35,7 +38,7 @@ public class FairLock implements Lock {
 
     @Override
     public boolean release() {
-        if(rLock.isHeldByCurrentThread()){
+        if (rLock.isHeldByCurrentThread()) {
 
             try {
                 return rLock.forceUnlockAsync().get();

--- a/src/main/java/org/springframework/boot/autoconfigure/klock/lock/Lock.java
+++ b/src/main/java/org/springframework/boot/autoconfigure/klock/lock/Lock.java
@@ -5,8 +5,11 @@ package org.springframework.boot.autoconfigure.klock.lock;
  */
 public interface Lock {
 
+    String name = "lock";
+
     boolean acquire();
 
     boolean release();
+
 }
 

--- a/src/main/java/org/springframework/boot/autoconfigure/klock/lock/LockFactory.java
+++ b/src/main/java/org/springframework/boot/autoconfigure/klock/lock/LockFactory.java
@@ -6,28 +6,41 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.klock.model.LockInfo;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * Created by kl on 2017/12/29.
  * Content :
  */
-public class LockFactory  {
-    Logger logger= LoggerFactory.getLogger(getClass());
+public class LockFactory {
+    Logger logger = LoggerFactory.getLogger(getClass());
 
     @Autowired
     private RedissonClient redissonClient;
 
-    public Lock getLock(LockInfo lockInfo){
-        switch (lockInfo.getType()) {
-            case Reentrant:
-                return new ReentrantLock(redissonClient, lockInfo);
-            case Fair:
-                return new FairLock(redissonClient, lockInfo);
-            case Read:
-                return new ReadLock(redissonClient, lockInfo);
-            case Write:
-                return new WriteLock(redissonClient, lockInfo);
-            default:
-                return new ReentrantLock(redissonClient, lockInfo);
+    public Lock getLock(LockInfo... lockInfos) {
+        if (lockInfos.length == 1) {
+            LockInfo lockInfo = lockInfos[0];
+            switch (lockInfo.getType()) {
+                case Reentrant:
+                    return new ReentrantLock(redissonClient, lockInfo);
+                case Fair:
+                    return new FairLock(redissonClient, lockInfo);
+                case Read:
+                    return new ReadLock(redissonClient, lockInfo);
+                case Write:
+                    return new WriteLock(redissonClient, lockInfo);
+
+                default:
+                    return new ReentrantLock(redissonClient, lockInfo);
+            }
+        } else {
+            List<LockInfo> targetLockInfos = new ArrayList<>();
+            for (int i = 0; i < lockInfos.length; i++) {
+                targetLockInfos.add(lockInfos[i]);
+            }
+            return new MultiLock(redissonClient, targetLockInfos);
         }
     }
 

--- a/src/main/java/org/springframework/boot/autoconfigure/klock/lock/LockFactory.java
+++ b/src/main/java/org/springframework/boot/autoconfigure/klock/lock/LockFactory.java
@@ -31,7 +31,6 @@ public class LockFactory {
                     return new ReadLock(redissonClient, lockInfo);
                 case Write:
                     return new WriteLock(redissonClient, lockInfo);
-
                 default:
                     return new ReentrantLock(redissonClient, lockInfo);
             }

--- a/src/main/java/org/springframework/boot/autoconfigure/klock/lock/MultiLock.java
+++ b/src/main/java/org/springframework/boot/autoconfigure/klock/lock/MultiLock.java
@@ -1,0 +1,55 @@
+package org.springframework.boot.autoconfigure.klock.lock;
+
+import org.redisson.RedissonMultiLock;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.boot.autoconfigure.klock.model.LockInfo;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * 联锁
+ * 将多个RLock对象关联为一个联锁
+ */
+public class MultiLock implements Lock {
+
+    private RedissonMultiLock rLock;
+
+    private RedissonClient redissonClient;
+
+    private final List<LockInfo> lockInfos;
+
+
+    public MultiLock(RedissonClient redissonClient, List<LockInfo> lockInfos) {
+        this.lockInfos = lockInfos;
+        this.redissonClient = redissonClient;
+        RLock[] rLocks = new RLock[lockInfos.size()];
+        for (int i = 0, length = lockInfos.size(); i < length; i++) {
+            RLock lock = redissonClient.getLock(lockInfos.get(i).getName());
+            rLocks[i] = lock;
+        }
+        this.rLock = new RedissonMultiLock(rLocks);
+    }
+
+    @Override
+    public boolean acquire() {
+        try {
+            LockInfo lockInfo = lockInfos.get(0);
+            return rLock.tryLock(lockInfo.getWaitTime(), lockInfo.getLeaseTime(), TimeUnit.SECONDS);
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    @Override
+    public boolean release() {
+        try {
+            rLock.unlock();
+        } catch (Exception e) {
+            return false;
+        }
+        return true;
+
+    }
+}

--- a/src/main/java/org/springframework/boot/autoconfigure/klock/lock/MultiLock.java
+++ b/src/main/java/org/springframework/boot/autoconfigure/klock/lock/MultiLock.java
@@ -13,6 +13,7 @@ import java.util.concurrent.TimeUnit;
  * 将多个RLock对象关联为一个联锁
  */
 public class MultiLock implements Lock {
+    private String name;
 
     private RedissonMultiLock rLock;
 
@@ -25,10 +26,14 @@ public class MultiLock implements Lock {
         this.lockInfos = lockInfos;
         this.redissonClient = redissonClient;
         RLock[] rLocks = new RLock[lockInfos.size()];
+        StringBuffer nameBuf = new StringBuffer();
         for (int i = 0, length = lockInfos.size(); i < length; i++) {
-            RLock lock = redissonClient.getLock(lockInfos.get(i).getName());
+            name = lockInfos.get(i).getName();
+            RLock lock = redissonClient.getLock(name);
             rLocks[i] = lock;
+            nameBuf.append(name);
         }
+        name = nameBuf.toString();
         this.rLock = new RedissonMultiLock(rLocks);
     }
 

--- a/src/main/java/org/springframework/boot/autoconfigure/klock/lock/ReadLock.java
+++ b/src/main/java/org/springframework/boot/autoconfigure/klock/lock/ReadLock.java
@@ -11,6 +11,7 @@ import java.util.concurrent.TimeUnit;
  * Created by kl on 2017/12/29.
  */
 public class ReadLock implements Lock {
+    private String name;
 
     private  RReadWriteLock rLock;
 
@@ -26,7 +27,8 @@ public class ReadLock implements Lock {
     @Override
     public boolean acquire() {
         try {
-            rLock=redissonClient.getReadWriteLock(lockInfo.getName());
+            name = lockInfo.getName();
+            rLock=redissonClient.getReadWriteLock(name);
             return rLock.readLock().tryLock(lockInfo.getWaitTime(), lockInfo.getLeaseTime(), TimeUnit.SECONDS);
         } catch (InterruptedException e) {
             return false;

--- a/src/main/java/org/springframework/boot/autoconfigure/klock/lock/ReentrantLock.java
+++ b/src/main/java/org/springframework/boot/autoconfigure/klock/lock/ReentrantLock.java
@@ -11,6 +11,7 @@ import java.util.concurrent.TimeUnit;
  * Created by kl on 2017/12/29.
  */
 public class ReentrantLock implements Lock {
+    private String name;
 
     private  RLock rLock;
 
@@ -25,7 +26,8 @@ public class ReentrantLock implements Lock {
     @Override
     public boolean acquire() {
         try {
-            rLock = redissonClient.getLock(lockInfo.getName());
+            name = lockInfo.getName();
+            rLock = redissonClient.getLock(name);
             return rLock.tryLock(lockInfo.getWaitTime(), lockInfo.getLeaseTime(), TimeUnit.SECONDS);
         } catch (InterruptedException e) {
             return false;

--- a/src/main/java/org/springframework/boot/autoconfigure/klock/lock/WriteLock.java
+++ b/src/main/java/org/springframework/boot/autoconfigure/klock/lock/WriteLock.java
@@ -11,14 +11,15 @@ import java.util.concurrent.TimeUnit;
  * Created by kl on 2017/12/29.
  */
 public class WriteLock implements Lock {
+    private String name;
 
-    private  RReadWriteLock rLock;
+    private RReadWriteLock rLock;
 
     private final LockInfo lockInfo;
 
     private RedissonClient redissonClient;
 
-    public WriteLock(RedissonClient redissonClient,LockInfo info) {
+    public WriteLock(RedissonClient redissonClient, LockInfo info) {
         this.redissonClient = redissonClient;
         this.lockInfo = info;
     }
@@ -26,7 +27,8 @@ public class WriteLock implements Lock {
     @Override
     public boolean acquire() {
         try {
-            rLock=redissonClient.getReadWriteLock(lockInfo.getName());
+            name = lockInfo.getName();
+            rLock = redissonClient.getReadWriteLock(name);
             return rLock.writeLock().tryLock(lockInfo.getWaitTime(), lockInfo.getLeaseTime(), TimeUnit.SECONDS);
         } catch (InterruptedException e) {
             return false;
@@ -35,7 +37,7 @@ public class WriteLock implements Lock {
 
     @Override
     public boolean release() {
-        if(rLock.writeLock().isHeldByCurrentThread()){
+        if (rLock.writeLock().isHeldByCurrentThread()) {
             try {
                 return rLock.writeLock().forceUnlockAsync().get();
             } catch (InterruptedException e) {

--- a/src/main/java/org/springframework/boot/autoconfigure/klock/model/LockType.java
+++ b/src/main/java/org/springframework/boot/autoconfigure/klock/model/LockType.java
@@ -20,7 +20,12 @@ public enum LockType {
     /**
      * 写锁
      */
-    Write;
+    Write,
+    /**
+     * 联锁
+     */
+    Multi,
+    ;
 
     LockType() {
     }

--- a/src/test/java/org/springframework/boot/autoconfigure/klock/test/KlockTests.java
+++ b/src/test/java/org/springframework/boot/autoconfigure/klock/test/KlockTests.java
@@ -20,232 +20,254 @@ import java.util.stream.IntStream;
 @SpringBootTest(classes = KlockTestApplication.class)
 public class KlockTests {
 
-	@Autowired
-	TestService testService;
+    @Autowired
+    TestService testService;
 
-	@Autowired
-	TimeoutService timeoutService;
+    @Autowired
+    TimeoutService timeoutService;
 
-	@Rule
-	public final ExpectedException exception = ExpectedException.none();
+    @Rule
+    public final ExpectedException exception = ExpectedException.none();
 
-	/**
-	 * 同一进程内多线程获取锁测试
-	 * @throws Exception
-	 */
-	@Test
-	public void multithreadingTest()throws Exception{
-		ExecutorService executorService = Executors.newFixedThreadPool(6);
-		IntStream.range(0,10).forEach(i-> executorService.submit(() -> {
-			try {
-				String result = testService.getValue("sleep");
-				System.err.println("线程:[" + Thread.currentThread().getName() + "]拿到结果=》" + result + new Date().toLocaleString());
-			} catch (Exception e) {
-				e.printStackTrace();
-			}
-		}));
-		executorService.awaitTermination(30, TimeUnit.SECONDS);
-	}
+    /**
+     * 同一进程内多线程获取锁测试
+     *
+     * @throws Exception
+     */
+    @Test
+    public void multithreadingTest() throws Exception {
+        ExecutorService executorService = Executors.newFixedThreadPool(6);
+        IntStream.range(0, 10).forEach(i -> executorService.submit(() -> {
+            try {
+                String result = testService.getValue("sleep");
+                System.err.println("线程:[" + Thread.currentThread().getName() + "]拿到结果=》" + result + new Date().toLocaleString());
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }));
+        executorService.awaitTermination(5, TimeUnit.SECONDS);
+    }
+
+    @Test
+    public void multiLockTest() throws Exception {
+        ExecutorService executorService = Executors.newFixedThreadPool(6);
+        IntStream.range(0, 10).forEach(i -> executorService.submit(() -> {
+            User originUser = new User(1, "xx");
+            User targetUser = new User(9, "tt");
+            testService.updateValue(originUser, targetUser);
+            System.out.println("origin:" + originUser.getId() + ",target:" + targetUser.getId());
+        }));
+        executorService.awaitTermination(30, TimeUnit.SECONDS);
+
+    }
 
 
-	/**
-	 *线程休眠50秒
-	 * @throws Exception
-	 */
-	@Test
-	public void jvm1()throws Exception{
-        String result=testService.getValue("sleep");
-		Assert.assertEquals(result,"success");
-	}
+    /**
+     * 线程休眠50秒
+     *
+     * @throws Exception
+     */
+    @Test
+    public void jvm1() throws Exception {
+        String result = testService.getValue("sleep");
+        Assert.assertEquals(result, "success");
+    }
 
-	/**
-	 *不休眠
-	 * @throws Exception
-	 */
-	@Test
-	public void jvm2()throws Exception{
-		String result=testService.getValue("noSleep");
-		Assert.assertEquals(result,"success");
-	}
-	/**
-	 *不休眠
-	 * @throws Exception
-	 */
-	@Test
-	public void jvm3()throws Exception{
-		String result=testService.getValue("noSleep");
-		Assert.assertEquals(result,"success");
-	}
-	//先后启动jvm1 和 jvm 2两个测试用例，会发现虽然 jvm2没休眠,因为getValue加锁了，
-	// 所以只要jvm1拿到锁就基本同时完成
+    /**
+     * 不休眠
+     *
+     * @throws Exception
+     */
+    @Test
+    public void jvm2() throws Exception {
+        String result = testService.getValue("noSleep");
+        Assert.assertEquals(result, "success");
+    }
 
-	/**
-	 * 测试业务key
-	 */
-	@Test
-	public void businessKeyJvm1()throws Exception{
-		String result=testService.getValue("user1",null);
-		Assert.assertEquals(result,"success");
-	}
-	/**
-	 * 测试业务key
-	 */
-	@Test
-	public void businessKeyJvm2()throws Exception{
-		String result=testService.getValue("user1",1);
-		Assert.assertEquals(result,"success");
-	}
-	/**
-	 * 测试业务key
-	 */
-	@Test
-	public void businessKeyJvm3()throws Exception{
-		String result=testService.getValue("user1",2);
-		Assert.assertEquals(result,"success");
-	}
-	/**
-	 * 测试业务key
-	 */
-	@Test
-	public void businessKeyJvm4()throws Exception{
-		String result=testService.getValue(new User(3,null));
-		Assert.assertEquals(result,"success");
-	}
+    /**
+     * 不休眠
+     *
+     * @throws Exception
+     */
+    @Test
+    public void jvm3() throws Exception {
+        String result = testService.getValue("noSleep");
+        Assert.assertEquals(result, "success");
+    }
+    //先后启动jvm1 和 jvm 2两个测试用例，会发现虽然 jvm2没休眠,因为getValue加锁了，
+    // 所以只要jvm1拿到锁就基本同时完成
 
-	/**
-	 * 测试watchdog无限延长加锁时间
-	 */
-	@Test
-	public void infiniteLeaseTime() {
-		timeoutService.foo1();
-	}
+    /**
+     * 测试业务key
+     */
+    @Test
+    public void businessKeyJvm1() throws Exception {
+        String result = testService.getValue("user1", null);
+        Assert.assertEquals(result, "success");
+    }
 
-	/**
-	 * 测试加锁超时快速失败
-	 */
-	@Test
-	public void lockTimeoutFailFast() throws InterruptedException {
+    /**
+     * 测试业务key
+     */
+    @Test
+    public void businessKeyJvm2() throws Exception {
+        String result = testService.getValue("user1", 1);
+        Assert.assertEquals(result, "success");
+    }
 
-		ExecutorService executorService = Executors.newFixedThreadPool(10);
+    /**
+     * 测试业务key
+     */
+    @Test
+    public void businessKeyJvm3() throws Exception {
+        String result = testService.getValue("user1", 2);
+        Assert.assertEquals(result, "success");
+    }
 
-		executorService.submit(() -> timeoutService.foo1());
+    /**
+     * 测试业务key
+     */
+    @Test
+    public void businessKeyJvm4() throws Exception {
+        String result = testService.getValue(new User(3, null));
+        Assert.assertEquals(result, "success");
+    }
 
-		TimeUnit.MILLISECONDS.sleep(1000);
+    /**
+     * 测试watchdog无限延长加锁时间
+     */
+    @Test
+    public void infiniteLeaseTime() {
+        timeoutService.foo1();
+    }
 
-		exception.expect(KlockTimeoutException.class);
-		timeoutService.foo2();
+    /**
+     * 测试加锁超时快速失败
+     */
+    @Test
+    public void lockTimeoutFailFast() throws InterruptedException {
 
-	}
+        ExecutorService executorService = Executors.newFixedThreadPool(10);
 
-	/**
-	 * 测试加锁超时阻塞等待
-	 * 会打印10次acquire lock
-	 */
-	@Test
-	public void lockTimeoutKeepAcquire() throws InterruptedException {
+        executorService.submit(() -> timeoutService.foo1());
 
-		ExecutorService executorService = Executors.newFixedThreadPool(10);
-		CountDownLatch startLatch = new CountDownLatch(1);
-		CountDownLatch endLatch = new CountDownLatch(10);
+        TimeUnit.MILLISECONDS.sleep(1000);
 
-		for(int i=0; i<10; i++) {
-			executorService.submit(() -> {
-				try {
-					startLatch.await();
-					timeoutService.foo3();
-				} catch (InterruptedException e) {
-					e.printStackTrace();
-				} finally {
-					endLatch.countDown();
-				}
-			});
-		}
+        exception.expect(KlockTimeoutException.class);
+        timeoutService.foo2();
 
-		long start = System.currentTimeMillis();
-		startLatch.countDown();
-		endLatch.await();
-		long end = System.currentTimeMillis();
-		Assert.assertTrue((end - start) >= 10*2*1000);
-	}
+    }
 
-	/**
-	 * 测试自定义加锁超时处理策略
-	 * 会执行1次自定义加锁超时处理策略
-	 */
-	@Test
-	public void lockTimeoutCustom() throws InterruptedException {
+    /**
+     * 测试加锁超时阻塞等待
+     * 会打印10次acquire lock
+     */
+    @Test
+    public void lockTimeoutKeepAcquire() throws InterruptedException {
 
-		ExecutorService executorService = Executors.newFixedThreadPool(10);
-		CountDownLatch latch = new CountDownLatch(2);
+        ExecutorService executorService = Executors.newFixedThreadPool(10);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch endLatch = new CountDownLatch(10);
 
-		executorService.submit(() -> {
-			timeoutService.foo1();
-			latch.countDown();
-		});
+        for (int i = 0; i < 10; i++) {
+            executorService.submit(() -> {
+                try {
+                    startLatch.await();
+                    timeoutService.foo3();
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                } finally {
+                    endLatch.countDown();
+                }
+            });
+        }
 
-		executorService.submit(() -> {
-			timeoutService.foo4("foo", "bar");
-			latch.countDown();
-		});
+        long start = System.currentTimeMillis();
+        startLatch.countDown();
+        endLatch.await();
+        long end = System.currentTimeMillis();
+        Assert.assertTrue((end - start) >= 10 * 2 * 1000);
+    }
 
-		latch.await();
-	}
+    /**
+     * 测试自定义加锁超时处理策略
+     * 会执行1次自定义加锁超时处理策略
+     */
+    @Test
+    public void lockTimeoutCustom() throws InterruptedException {
 
-	/**
-	 * 测试加锁超时不做处理
-	 */
-	@Test
-	public void lockTimeoutNoOperation() throws InterruptedException {
+        ExecutorService executorService = Executors.newFixedThreadPool(10);
+        CountDownLatch latch = new CountDownLatch(2);
 
-		ExecutorService executorService = Executors.newFixedThreadPool(10);
-		CountDownLatch startLatch = new CountDownLatch(1);
-		CountDownLatch endLatch = new CountDownLatch(10);
+        executorService.submit(() -> {
+            timeoutService.foo1();
+            latch.countDown();
+        });
 
-		for(int i=0; i<10; i++) {
-			executorService.submit(() -> {
-				try {
-					startLatch.await();
-					timeoutService.foo5("foo", "bar");
-				} catch (Exception e) {
-					e.printStackTrace();
-				} finally {
-					endLatch.countDown();
-				}
-			});
+        executorService.submit(() -> {
+            timeoutService.foo4("foo", "bar");
+            latch.countDown();
+        });
 
-		}
+        latch.await();
+    }
 
-		long start = System.currentTimeMillis();
-		startLatch.countDown();
-		endLatch.await();
-		long end = System.currentTimeMillis();
-		Assert.assertTrue((end - start) < 10*2*1000);
-	}
+    /**
+     * 测试加锁超时不做处理
+     */
+    @Test
+    public void lockTimeoutNoOperation() throws InterruptedException {
 
-	/**
-	 * 测试释放锁时已超时，不做处理
-	 */
-	@Test
-	public void releaseTimeoutNoOperation() {
+        ExecutorService executorService = Executors.newFixedThreadPool(10);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch endLatch = new CountDownLatch(10);
 
-		timeoutService.foo6("foo", "bar");
-	}
+        for (int i = 0; i < 10; i++) {
+            executorService.submit(() -> {
+                try {
+                    startLatch.await();
+                    timeoutService.foo5("foo", "bar");
+                } catch (Exception e) {
+                    e.printStackTrace();
+                } finally {
+                    endLatch.countDown();
+                }
+            });
 
-	/**
-	 * 测试释放锁时已超时，快速失败
-	 */
-	@Test
-	public void releaseTimeoutFailFast() {
+        }
 
-		exception.expect(KlockTimeoutException.class);
-		timeoutService.foo7("foo", "bar");
-	}
-	/**
-	 * 测试释放锁时已超时，自定义策略
-	 */
-	@Test
-	public void releaseTimeoutCustom(){
-		exception.expect(IllegalStateException.class);
-		timeoutService.foo8("foo", "bar");
-	}
+        long start = System.currentTimeMillis();
+        startLatch.countDown();
+        endLatch.await();
+        long end = System.currentTimeMillis();
+        Assert.assertTrue((end - start) < 10 * 2 * 1000);
+    }
+
+    /**
+     * 测试释放锁时已超时，不做处理
+     */
+    @Test
+    public void releaseTimeoutNoOperation() {
+
+        timeoutService.foo6("foo", "bar");
+    }
+
+    /**
+     * 测试释放锁时已超时，快速失败
+     */
+    @Test
+    public void releaseTimeoutFailFast() {
+
+        exception.expect(KlockTimeoutException.class);
+        timeoutService.foo7("foo", "bar");
+    }
+
+    /**
+     * 测试释放锁时已超时，自定义策略
+     */
+    @Test
+    public void releaseTimeoutCustom() {
+        exception.expect(IllegalStateException.class);
+        timeoutService.foo8("foo", "bar");
+    }
 }

--- a/src/test/java/org/springframework/boot/autoconfigure/klock/test/TestService.java
+++ b/src/test/java/org/springframework/boot/autoconfigure/klock/test/TestService.java
@@ -11,23 +11,32 @@ import org.springframework.stereotype.Service;
 @Service
 public class TestService {
 
-    @Klock(waitTime = 10,leaseTime = 60,keys = {"#param"},lockTimeoutStrategy = LockTimeoutStrategy.FAIL_FAST)
+    @Klock(waitTime = 10, leaseTime = 60, keys = {"#param"}, lockTimeoutStrategy = LockTimeoutStrategy.FAIL_FAST)
     public String getValue(String param) throws Exception {
-      //  if ("sleep".equals(param)) {//线程休眠或者断点阻塞，达到一直占用锁的测试效果
-            Thread.sleep(1000*3);
+        //  if ("sleep".equals(param)) {//线程休眠或者断点阻塞，达到一直占用锁的测试效果
+//        Thread.sleep(1000 );
         //}
         return "success";
     }
 
     @Klock(keys = {"#userId"})
-    public String getValue(String userId,@KlockKey Integer id)throws Exception{
-        Thread.sleep(60*1000);
+    public String getValue(String userId, @KlockKey Integer id) throws Exception {
+        Thread.sleep(60 * 1000);
         return "success";
     }
 
-    @Klock(keys = {"#user.name","#user.id"})
-    public String getValue(User user)throws Exception{
-        Thread.sleep(60*1000);
+    @Klock(keys = {"#user.name", "#user.id"})
+    public String getValue(User user) throws Exception {
+        Thread.sleep(60 * 1000);
+        return "success";
+    }
+
+    @Klock
+    public String updateValue(@KlockKey User originUser, @KlockKey User targetUser) {
+        int randNum = (int) Math.round(Math.random()*10);
+        originUser.setId(originUser.getId() - randNum);
+        targetUser.setId(targetUser.getId() + randNum);
+        System.out.println("thread" + Thread.currentThread().getId() + "-randNum:" + randNum);
         return "success";
     }
 

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,2 +1,3 @@
-spring.klock.address=192.168.1.204:6379
-#spring.klock.cluster-server.node-addresses=127.0.0.1:7000,127.0.0.1:7001£¬127.0.0.1:7002,127.0.0.1:7003£¬127.0.0.1:7004,127.0.0.1:7005
+spring.klock.address=127.0.0.1:6379
+spring.klock.password=xuguangwu
+#spring.klock.cluster-server.node-addresses=127.0.0.1:7000,127.0.0.1:7001ï¿½ï¿½127.0.0.1:7002,127.0.0.1:7003ï¿½ï¿½127.0.0.1:7004,127.0.0.1:7005


### PR DESCRIPTION
1. 因业务需求，需要同时锁住两笔账单做处理，该框架尚不支持MultiLock，就进行了改造。我的思路是如果参数中有多个标记了@KlockKey的就说明需要对多行数据加锁，且@KlockKey与@Klock中的keys作用有重合，所以单独拿出来作联锁处理。LockFactory中的getLock方法入参为可变，可以传入多个LockInfo，进而实例化多个锁对象。
2. 单词拼写错误KlockAspectHandler中的curentLock
3. 我建议代码可以格式化

希望可以采纳，谢谢